### PR TITLE
Prefer selecting buffers over reading files

### DIFF
--- a/lua/torus/ring.lua
+++ b/lua/torus/ring.lua
@@ -100,13 +100,21 @@ function M.go_to(index)
   local filename = vim.g.torus_files[index]
 
   if filename then
-    vim.cmd(":edit " .. filename)
+    M.go_to_filename(filename)
   end
 end
 
 function M.go_to_filename(filename)
-  vim.cmd(":edit " .. filename)
+  -- If we've already got the file open, switch to it instead of reading
+  local existing = vim.fn.bufnr(filename)
+  if existing ~= -1 then
+    vim.cmd.buffer(existing)
+    return
+  end
+
+  vim.cmd.edit(filename)
 end
+
 
 function M.next()
   local current_index = M.is_saved(utils.buffer_to_path("%"))

--- a/lua/torus/ui.lua
+++ b/lua/torus/ui.lua
@@ -63,7 +63,7 @@ function M.open_window()
     local line = vim.api.nvim_get_current_line()
 
     vim.api.nvim_win_close(winid, { force = true })
-    vim.cmd(":edit " .. line)
+    ring.go_to_filename(line)
   end, { noremap = true, silent = true, buffer = bufnr })
 
 


### PR DESCRIPTION
Using `vim.cmd.buffer` will switch to an existing buffer as opposed to `vim.cmd.edit` which will always read the file. This is less destructive and prevents errors when a buffer has unsaved change.